### PR TITLE
Fix early return in FindStaticFindObject

### DIFF
--- a/UnrealDumper/offsets.cpp
+++ b/UnrealDumper/offsets.cpp
@@ -452,8 +452,8 @@ uintptr_t OffsetsFinder::FindStaticFindObject() {
 
     if (StaticFindObjectAddr == 0) {
         StaticFindObjectAddr = (uintptr_t)Memory::FortKit::FindByString(L"/Temp/%s", { Memory::FortKit::ASM::LEA });
-        return 0;
-        return StaticFindObjectAddr;
+        if (StaticFindObjectAddr == 0)
+            return 0;
     }
 
     for (StaticFindObjectAddr; StaticFindObjectAddr > 0; StaticFindObjectAddr -= 1) {


### PR DESCRIPTION
## Summary
- fix unreachable code in `OffsetsFinder::FindStaticFindObject`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842778521c8832780ba629bbbd3786a